### PR TITLE
Feature: atoms input text button

### DIFF
--- a/apps/realstate-front/src/app/components/atoms/Button/Button.tsx
+++ b/apps/realstate-front/src/app/components/atoms/Button/Button.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface ButtonProps {
+  label: string;
+  variant?: 'primary' | 'secondary';
+  onClick?: () => void;
+}
+
+const Button: React.FC<ButtonProps> = ({ label, variant = 'primary', onClick }) => {
+  let buttonStyles = 'px-6 py-2 rounded focus:outline-none';
+
+  if (variant === 'primary') {
+    buttonStyles += ' bg-blue-500 text-white hover:bg-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50';
+  } else if (variant === 'secondary') {
+    buttonStyles += ' bg-gray-200 text-gray-700 hover:bg-gray-300 focus:ring-2 focus:ring-gray-300 focus:ring-opacity-50';
+  }
+
+  return (
+    <button className={buttonStyles} onClick={onClick}>
+      {label}
+    </button>
+  );
+};
+
+export default Button;

--- a/apps/realstate-front/src/app/components/atoms/Input/Input.tsx
+++ b/apps/realstate-front/src/app/components/atoms/Input/Input.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+interface InputProps {
+  placeholder: string;
+}
+
+const Input: React.FC<InputProps> = ({ placeholder }) => {
+  return (
+    <input className="border-2 border-gray-300 rounded-md p-2" placeholder={placeholder} />
+  )
+} 
+
+export default Input

--- a/apps/realstate-front/src/app/components/atoms/Text/Text.tsx
+++ b/apps/realstate-front/src/app/components/atoms/Text/Text.tsx
@@ -1,0 +1,34 @@
+// write a component that renders a title with a given text
+import React from 'react'
+
+interface TextProps {
+  text: string;
+  className?: string;
+  textType: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
+  children?: React.ReactNode | string;
+}
+
+const Text: React.FC<TextProps> = ({ text, className="", textType, children }) => {
+  switch (textType) {
+    case 'h1':
+      return <h1 className={className}>{children}</h1>
+    case 'h2':
+      return <h2 className={className}>{children}</h2>
+    case 'h3':
+      return <h3 className={className}>{children}</h3>
+    case 'h4':
+      return <h4 className={className}>{children}</h4>
+    case 'h5':
+      return <h5 className={className}>{children}</h5>
+    case 'h6':
+      return <h6 className={className}>{children}</h6>
+    case 'p':
+      return <p className={className}>{children}</p>
+    case 'span':
+      return <span className={className}>{children}</span>
+    default:
+      return <h1 className={className}>{children}</h1>
+  }
+}
+
+export default Text

--- a/apps/realstate-front/src/app/components/atoms/index.tsx
+++ b/apps/realstate-front/src/app/components/atoms/index.tsx
@@ -1,0 +1,5 @@
+import Button from './Button/Button';
+import Input from './Input/Input';
+import Text from './Text/Text';
+
+export { Button, Input, Text };


### PR DESCRIPTION
### 📌 Pull Request Description:

Creation of Atoms for :
 - Button
    `ButtonProps {
        label: string;
        variant?: 'primary' | 'secondary';
        onClick?: () => void;
      } `
 - Input
    `interface InputProps {
  placeholder: string;
}`
 - Text
    `TextProps {
  text: string;
  className?: string;
  textType: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
  children?: React.ReactNode | string;
}`

### 🔍 What does this PR change?

**Feature/Enhancement:** 
    - Adding atoms for Button, Text and Input components


### 📋 Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
